### PR TITLE
add Parser for Symfony console table and spec for it

### DIFF
--- a/spec/Service/TableParserSpec.php
+++ b/spec/Service/TableParserSpec.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Created by solutionDrive GmbH
+ *
+ * @copyright 2018 solutionDrive GmbH
+ */
+
+namespace spec\sd\SwPluginManager\Service;
+
+use PhpSpec\ObjectBehavior;
+use sd\SwPluginManager\Service\TableParser;
+
+class TableParserSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(TableParser::class);
+    }
+
+    public function it_can_parse_a_very_simple_table()
+    {
+        $this->beConstructedWith(
+            ',',
+            "\n",
+            3
+        );
+
+        $inputTable = 'firstColumn,secondColumn,third';
+
+        $parsedTable = $this->parse($inputTable);
+        $parsedTable->shouldEqual(
+            [
+                ['firstColumn', 'secondColumn', 'third'],
+            ]
+        );
+    }
+
+    public function it_can_parse_a_symfony_style_table()
+    {
+        $this->beConstructedWith(
+            '|',
+            "\n",
+            3,
+            true,
+            true
+        );
+
+        $inputTable = <<<EOT
++-------------------+-------------------------+---------+
+| firstColumn       | secondColumn            | third   |
++-------------------+-------------------------+---------+
+| line1 col1        | line1 col2              | 1.3     |
+| line2 col1        | line2 col2              | 2.3     |
+| line3 col1        | line3 col2              | 3.3     |
++-------------------+-------------------------+---------+
+EOT;
+
+        $parsedTable = $this->parse($inputTable);
+        $parsedTable->shouldEqual(
+            [
+                ['firstColumn', 'secondColumn', 'third'],
+                ['line1 col1', 'line1 col2', '1.3'],
+                ['line2 col1', 'line2 col2', '2.3'],
+                ['line3 col1', 'line3 col2', '3.3'],
+            ]
+        );
+    }
+
+    public function it_can_parse_another_table()
+    {
+        $this->beConstructedWith(
+            '/',
+            "\n",
+            2,
+            false,
+            false
+        );
+
+        $inputTable = <<<EOT
+ firstColumn       / secondColumn            / third 
+-------------------+-------------------------+-------
+ line1 col1        / line1 col2              / 1.3   
+ line2 col1        / line2 col2              / 2.3   
+ line3 col1        / line3 col2              / 3.3   
+EOT;
+
+        $parsedTable = $this->parse($inputTable);
+        $parsedTable->shouldEqual(
+            [
+                ['firstColumn', 'secondColumn', 'third'],
+                ['line1 col1', 'line1 col2', '1.3'],
+                ['line2 col1', 'line2 col2', '2.3'],
+                ['line3 col1', 'line3 col2', '3.3'],
+            ]
+        );
+    }
+}

--- a/src/Service/TableParser.php
+++ b/src/Service/TableParser.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Created by solutionDrive GmbH
+ *
+ * @copyright 2018 solutionDrive GmbH
+ */
+
+namespace sd\SwPluginManager\Service;
+
+class TableParser
+{
+    /** @var string */
+    private $cellSeparator;
+
+    /** @var string */
+    private $lineSeparator;
+
+    /** @var int */
+    private $minCellsPerRow;
+
+    /** @var bool */
+    private $stripFirstCell;
+
+    /** @var bool */
+    private $stripLastCell;
+
+    /**
+     * @param string $cellSeparator  Character that separates columns from each other (usually "|")
+     * @param string $lineSeparator  Character that separates lines from each other (usually "\n")
+     * @param int    $minCellsPerRow rows with less than this number of cells are ignored in output
+     * @param bool   $stripFirstCell if set to true, the first cell will be removed from each line
+     * @param bool   $stripLastCell  if set to true, the last cell will be removed from each line
+     */
+    public function __construct(
+        $cellSeparator = '|',
+        $lineSeparator = "\n",
+        $minCellsPerRow = 6,
+        $stripFirstCell = false,
+        $stripLastCell = false
+    ) {
+        $this->cellSeparator = $cellSeparator;
+        $this->lineSeparator = $lineSeparator;
+        $this->minCellsPerRow = $minCellsPerRow;
+        $this->stripFirstCell = $stripFirstCell;
+        $this->stripLastCell = $stripLastCell;
+    }
+
+    /**
+     * @param string $input
+     *
+     * @return array
+     */
+    public function parse($input)
+    {
+        $lines = explode($this->lineSeparator, $input);
+        $items = [];
+        foreach ($lines as $line) {
+            $splittedLine = $this->parseLine($line);
+            if (count($splittedLine) >= $this->minCellsPerRow) {
+                $items[] = $splittedLine;
+            }
+        }
+
+        return $items;
+    }
+
+    private function parseLine($line)
+    {
+        $line = trim($line);
+        $cells = explode($this->cellSeparator, $line);
+        array_walk($cells, function (&$value, $key) {
+            $value = trim($value);
+        });
+
+        if ($this->stripFirstCell) {
+            array_shift($cells);
+        }
+
+        if ($this->stripLastCell) {
+            array_pop($cells);
+        }
+
+        return $cells;
+    }
+}


### PR DESCRIPTION
We want to parse such tables to read Shopware's currenct plugins states:
![bildschirmfoto 2018-08-02 um 18 23 01](https://user-images.githubusercontent.com/7523691/43597053-3d3890ca-9681-11e8-9a0d-74d4e3fdd765.png)
