### PR TITLE
Cleanup shopware store api support

### DIFF
--- a/spec/Provider/StoreApiProviderSpec.php
+++ b/spec/Provider/StoreApiProviderSpec.php
@@ -8,15 +8,10 @@
 
 namespace spec\sd\SwPluginManager\Provider;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\RequestOptions;
 use PhpSpec\ObjectBehavior;
-use Psr\Http\Message\StreamInterface;
 use sd\SwPluginManager\Provider\ProviderInterface;
 use sd\SwPluginManager\Provider\StoreApiProvider;
 use sd\SwPluginManager\Service\StoreApiConnectorInterface;
-use sd\SwPluginManager\Service\StreamTranslatorInterface;
 
 class StoreApiProviderSpec extends ObjectBehavior
 {

--- a/spec/Provider/StoreApiProviderSpec.php
+++ b/spec/Provider/StoreApiProviderSpec.php
@@ -15,6 +15,7 @@ use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\StreamInterface;
 use sd\SwPluginManager\Provider\ProviderInterface;
 use sd\SwPluginManager\Provider\StoreApiProvider;
+use sd\SwPluginManager\Service\StoreApiConnectorInterface;
 use sd\SwPluginManager\Service\StreamTranslatorInterface;
 
 class StoreApiProviderSpec extends ObjectBehavior
@@ -36,209 +37,26 @@ class StoreApiProviderSpec extends ObjectBehavior
     }
 
     public function let(
-        Client $guzzleClient,
-        StreamTranslatorInterface $streamTranslator
+        StoreApiConnectorInterface $storeApiConnector
     ) {
         $this->beConstructedWith(
-            $guzzleClient,
-            $streamTranslator
+            $storeApiConnector
         );
-
-        // Resets environment variables on every run
-        putenv('SHOPWARE_ACCOUNT_USER=');
-        putenv('SHOPWARE_ACCOUNT_PASSWORD=');
-        putenv('SHOPWARE_SHOP_DOMAIN=');
     }
 
     public function it_can_load_a_plugin_with_correct_credentials(
-        Client $guzzleClient,
-        StreamTranslatorInterface $streamTranslator,
-        Response $accessTokenResponse,
-        StreamInterface $accessCodeStream,
-        Response $partnerResponse,
-        StreamInterface $partnerStream,
-        Response $clientshopsResponse,
-        StreamInterface $clientshopsStream,
-        Response $shopsResponse,
-        StreamInterface $shopsStream,
-        Response $licenseResponse,
-        StreamInterface $licenseStream,
-        Response $pluginResponse
+        StoreApiConnectorInterface $storeApiConnector
     ) {
-        putenv('SHOPWARE_ACCOUNT_USER=' . self::SHOPWARE_ACCOUNT_USER);
-        putenv('SHOPWARE_ACCOUNT_PASSWORD=' . self::SHOPWARE_ACCOUNT_PASSWORD);
-        putenv('SHOPWARE_SHOP_DOMAIN=' . self::SHOPWARE_SHOP_DOMAIN);
-
-        // ACCESS TOKEN
-        $guzzleClient->post(
-            self::BASE_URL . '/accesstokens',
-            [
-                RequestOptions::JSON => [
-                    'shopwareId'    => self::SHOPWARE_ACCOUNT_USER,
-                    'password'      => self::SHOPWARE_ACCOUNT_PASSWORD,
-                ],
-            ]
-        )
-        ->shouldBeCalled()
-        ->willReturn($accessTokenResponse);
-
-        $accessTokenResponse->getStatusCode()
-            ->willReturn(200);
-
-        $accessTokenResponse->getBody()
-            ->willReturn($accessCodeStream);
-
-        $accessCodeData = [
-            'token'     => 'ABCDEF',
-            'userId'    => '12345',
-        ];
-
-        $streamTranslator->translateToArray($accessCodeStream)
-            ->willReturn($accessCodeData);
-
-        // CHECK FOR PARTNER ACCOUNT
-        $guzzleClient->get(
-            self::BASE_URL . '/partners/12345',
-            [
-                RequestOptions::HEADERS => [
-                    'X-Shopware-Token'  => 'ABCDEF',
-                ],
-            ]
-        )
-        ->shouldBeCalled()
-        ->willReturn($partnerResponse);
-
-        $partnerResponse->getStatusCode()
-            ->willReturn(200);
-
-        $partnerResponse->getBody()
-            ->willReturn($partnerStream);
-
-        $partnerData = [
-            'partnerId' => '9876',
-        ];
-
-        $streamTranslator->translateToArray($partnerStream)
-            ->willReturn($partnerData);
-
-        // GET ALL AVAILABLE PARTNER CLIENTSHOPS
-        $guzzleClient->get(
-            self::BASE_URL . '/partners/12345/clientshops',
-            [
-                RequestOptions::HEADERS => [
-                    'X-Shopware-Token'  => 'ABCDEF',
-                ],
-            ]
-        )
-        ->shouldBeCalled()
-        ->willReturn($clientshopsResponse);
-
-        $clientshopsResponse->getStatusCode()
-            ->willReturn(200);
-
-        $clientshopsResponse->getBody()
-            ->willReturn($clientshopsStream);
-
-        $clientshopData = [
-            [
-                'id' => 1,
-                'domain' => 'example.com',
-            ],
-        ];
-
-        $streamTranslator->translateToArray($clientshopsStream)
-            ->willReturn($clientshopData);
-
-        // GET ALL SHOPS DIRECTLY CONNECTED TO ACCOUNT
-        $guzzleClient->get(
-            self::BASE_URL . '/shops?userId=12345',
-            [
-                RequestOptions::HEADERS => [
-                    'X-Shopware-Token'  => 'ABCDEF',
-                ],
-            ]
-        )
-        ->shouldBeCalled()
-        ->willReturn($shopsResponse);
-
-        $shopsResponse->getStatusCode()
-            ->willReturn(200);
-
-        $shopsResponse->getBody()
-            ->willReturn($shopsStream);
-
-        $shopsData = [
-            [
-                'id' => 5,
-                'domain' => 'example.org',
-            ],
-        ];
-
-        $streamTranslator->translateToArray($shopsStream)
-            ->willReturn($shopsData);
-
-        // GET ALL LICENSES
-        $guzzleClient->get(
-            self::BASE_URL . '/licenses?shopId=5&partnerId=12345',
-            [
-                RequestOptions::HEADERS => [
-                    'X-Shopware-Token'  => 'ABCDEF',
-                ],
-            ]
-        )
-        ->shouldBeCalled()
-        ->willReturn($licenseResponse);
-
-        $licenseResponse->getStatusCode()
-            ->willReturn(200);
-
-        $licenseResponse->getBody()
-            ->willReturn($licenseStream);
-
-        $licenseData = [
-            [
-                'plugin' => [
-                    'name' => 'awesomePlugin',
-                    'binaries' => [
-                        [
-                            'version' => '0.0.1',
-                            'filePath' => '/plugin0.0.1',
-                        ],
-                        [
-                            'version' => '0.0.2',
-                            'filePath' => '/plugin0.0.2',
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $streamTranslator->translateToArray($licenseStream)
-            ->willReturn($licenseData);
-
-        $guzzleClient->get(
-            self::BASE_URL . '/plugin0.0.2?shopId=5',
-            [
-                RequestOptions::HEADERS => [
-                    'X-Shopware-Token'  => 'ABCDEF',
-                ],
-                RequestOptions::SINK => '/tmp/sw-plugin-awesomePlugin0.0.2',
-            ]
-        )
-        ->shouldBeCalled()
-        ->willReturn($pluginResponse);
+        $storeApiConnector->loadPlugin('awesomePlugin', '0.0.2')
+            ->willReturn('/tmp/plugin');
 
         $this->loadFile(
             [
                 'pluginId' => 'awesomePlugin',
                 'version'  => '0.0.2',
             ]
-        );
-    }
-
-    public function it_cannot_connect_to_store_api_without_credentials()
-    {
-        $this->shouldThrow(\RuntimeException::class)->during('loadFile', [[]]);
+        )
+        ->shouldReturn('/tmp/plugin');
     }
 
     public function it_supports()

--- a/spec/Service/StoreApiConnectorSpec.php
+++ b/spec/Service/StoreApiConnectorSpec.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Created by solutionDrive GmbH
+ *
+ * @copyright 2018 solutionDrive GmbH
+ */
+
+namespace spec\sd\SwPluginManager\Service;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use sd\SwPluginManager\Service\StoreApiConnector;
+use sd\SwPluginManager\Service\StoreApiConnectorInterface;
+
+class StoreApiConnectorSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(StoreApiConnector::class);
+    }
+
+    public function it_implements_StoreApiConnector_interface()
+    {
+        $this->shouldImplement(StoreApiConnectorInterface::class);
+    }
+}

--- a/spec/Service/StoreApiConnectorSpec.php
+++ b/spec/Service/StoreApiConnectorSpec.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /*
  * Created by solutionDrive GmbH
@@ -9,10 +8,11 @@ declare(strict_types=1);
 
 namespace spec\sd\SwPluginManager\Service;
 
+use GuzzleHttp\Client;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use sd\SwPluginManager\Service\StoreApiConnector;
 use sd\SwPluginManager\Service\StoreApiConnectorInterface;
+use sd\SwPluginManager\Service\StreamTranslatorInterface;
 
 class StoreApiConnectorSpec extends ObjectBehavior
 {
@@ -24,5 +24,20 @@ class StoreApiConnectorSpec extends ObjectBehavior
     public function it_implements_StoreApiConnector_interface()
     {
         $this->shouldImplement(StoreApiConnectorInterface::class);
+    }
+
+    public function let(
+        Client $guzzleClient,
+        StreamTranslatorInterface $streamTranslator
+    ) {
+        $this->beConstructedWith(
+            $guzzleClient,
+            $streamTranslator
+        );
+
+        // Resets environment variables on every run
+        putenv('SHOPWARE_ACCOUNT_USER=');
+        putenv('SHOPWARE_ACCOUNT_PASSWORD=');
+        putenv('SHOPWARE_SHOP_DOMAIN=');
     }
 }

--- a/spec/Service/StoreApiConnectorSpec.php
+++ b/spec/Service/StoreApiConnectorSpec.php
@@ -9,13 +9,22 @@
 namespace spec\sd\SwPluginManager\Service;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
 use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\StreamInterface;
 use sd\SwPluginManager\Service\StoreApiConnector;
 use sd\SwPluginManager\Service\StoreApiConnectorInterface;
 use sd\SwPluginManager\Service\StreamTranslatorInterface;
 
 class StoreApiConnectorSpec extends ObjectBehavior
 {
+    const BASE_URL = 'https://api.shopware.com';
+
+    const SHOPWARE_ACCOUNT_USER = 'NotExistingShopwareAccount';
+    const SHOPWARE_ACCOUNT_PASSWORD = 'SuperSecurePassword';
+    const SHOPWARE_SHOP_DOMAIN = 'example.org';
+
     public function it_is_initializable()
     {
         $this->shouldHaveType(StoreApiConnector::class);
@@ -39,5 +48,191 @@ class StoreApiConnectorSpec extends ObjectBehavior
         putenv('SHOPWARE_ACCOUNT_USER=');
         putenv('SHOPWARE_ACCOUNT_PASSWORD=');
         putenv('SHOPWARE_SHOP_DOMAIN=');
+    }
+
+    public function it_can_load_a_plugin_with_correct_credentials(
+        Client $guzzleClient,
+        StreamTranslatorInterface $streamTranslator,
+        Response $accessTokenResponse,
+        StreamInterface $accessCodeStream,
+        Response $partnerResponse,
+        StreamInterface $partnerStream,
+        Response $clientshopsResponse,
+        StreamInterface $clientshopsStream,
+        Response $shopsResponse,
+        StreamInterface $shopsStream,
+        Response $licenseResponse,
+        StreamInterface $licenseStream,
+        Response $pluginResponse
+    ) {
+        putenv('SHOPWARE_ACCOUNT_USER=' . self::SHOPWARE_ACCOUNT_USER);
+        putenv('SHOPWARE_ACCOUNT_PASSWORD=' . self::SHOPWARE_ACCOUNT_PASSWORD);
+        putenv('SHOPWARE_SHOP_DOMAIN=' . self::SHOPWARE_SHOP_DOMAIN);
+
+        // ACCESS TOKEN
+        $guzzleClient->post(
+            self::BASE_URL . '/accesstokens',
+            [
+                RequestOptions::JSON => [
+                    'shopwareId'    => self::SHOPWARE_ACCOUNT_USER,
+                    'password'      => self::SHOPWARE_ACCOUNT_PASSWORD,
+                ],
+            ]
+        )
+            ->shouldBeCalled()
+            ->willReturn($accessTokenResponse);
+
+        $accessTokenResponse->getStatusCode()
+            ->willReturn(200);
+
+        $accessTokenResponse->getBody()
+            ->willReturn($accessCodeStream);
+
+        $accessCodeData = [
+            'token'     => 'ABCDEF',
+            'userId'    => '12345',
+        ];
+
+        $streamTranslator->translateToArray($accessCodeStream)
+            ->willReturn($accessCodeData);
+
+        // CHECK FOR PARTNER ACCOUNT
+        $guzzleClient->get(
+            self::BASE_URL . '/partners/12345',
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => 'ABCDEF',
+                ],
+            ]
+        )
+            ->shouldBeCalled()
+            ->willReturn($partnerResponse);
+
+        $partnerResponse->getStatusCode()
+            ->willReturn(200);
+
+        $partnerResponse->getBody()
+            ->willReturn($partnerStream);
+
+        $partnerData = [
+            'partnerId' => '9876',
+        ];
+
+        $streamTranslator->translateToArray($partnerStream)
+            ->willReturn($partnerData);
+
+        // GET ALL AVAILABLE PARTNER CLIENTSHOPS
+        $guzzleClient->get(
+            self::BASE_URL . '/partners/12345/clientshops',
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => 'ABCDEF',
+                ],
+            ]
+        )
+            ->shouldBeCalled()
+            ->willReturn($clientshopsResponse);
+
+        $clientshopsResponse->getStatusCode()
+            ->willReturn(200);
+
+        $clientshopsResponse->getBody()
+            ->willReturn($clientshopsStream);
+
+        $clientshopData = [
+            [
+                'id' => 1,
+                'domain' => 'example.com',
+            ],
+        ];
+
+        $streamTranslator->translateToArray($clientshopsStream)
+            ->willReturn($clientshopData);
+
+        // GET ALL SHOPS DIRECTLY CONNECTED TO ACCOUNT
+        $guzzleClient->get(
+            self::BASE_URL . '/shops?userId=12345',
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => 'ABCDEF',
+                ],
+            ]
+        )
+            ->shouldBeCalled()
+            ->willReturn($shopsResponse);
+
+        $shopsResponse->getStatusCode()
+            ->willReturn(200);
+
+        $shopsResponse->getBody()
+            ->willReturn($shopsStream);
+
+        $shopsData = [
+            [
+                'id' => 5,
+                'domain' => 'example.org',
+            ],
+        ];
+
+        $streamTranslator->translateToArray($shopsStream)
+            ->willReturn($shopsData);
+
+        // GET ALL LICENSES
+        $guzzleClient->get(
+            self::BASE_URL . '/licenses?shopId=5&partnerId=12345',
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => 'ABCDEF',
+                ],
+            ]
+        )
+            ->shouldBeCalled()
+            ->willReturn($licenseResponse);
+
+        $licenseResponse->getStatusCode()
+            ->willReturn(200);
+
+        $licenseResponse->getBody()
+            ->willReturn($licenseStream);
+
+        $licenseData = [
+            [
+                'plugin' => [
+                    'name' => 'awesomePlugin',
+                    'binaries' => [
+                        [
+                            'version' => '0.0.1',
+                            'filePath' => '/plugin0.0.1',
+                        ],
+                        [
+                            'version' => '0.0.2',
+                            'filePath' => '/plugin0.0.2',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $streamTranslator->translateToArray($licenseStream)
+            ->willReturn($licenseData);
+
+        $guzzleClient->get(
+            self::BASE_URL . '/plugin0.0.2?shopId=5',
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => 'ABCDEF',
+                ],
+                RequestOptions::SINK => '/tmp/sw-plugin-awesomePlugin0.0.2',
+            ]
+        )
+            ->shouldBeCalled()
+            ->willReturn($pluginResponse);
+
+        $this->loadPlugin('awesomePlugin', '0.0.2');
+    }
+
+    public function it_cannot_connect_to_store_api_without_credentials()
+    {
+        $this->shouldThrow(\RuntimeException::class)->during('loadPlugin', ['awesomePlugin', '0.0.2']);
     }
 }

--- a/spec/Service/StoreApiConnectorSpec.php
+++ b/spec/Service/StoreApiConnectorSpec.php
@@ -178,8 +178,8 @@ class StoreApiConnectorSpec extends ObjectBehavior
         Client $guzzleClient,
         StreamTranslatorInterface $streamTranslator,
         Response $accessTokenResponse,
-        StreamInterface $accessCodeStream)
-    {
+        StreamInterface $accessCodeStream
+    ) {
         $guzzleClient->post(
             self::BASE_URL . '/accesstokens',
             [

--- a/src/Provider/StoreApiProvider.php
+++ b/src/Provider/StoreApiProvider.php
@@ -8,10 +8,7 @@
 
 namespace sd\SwPluginManager\Provider;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\RequestOptions;
 use sd\SwPluginManager\Service\StoreApiConnectorInterface;
-use sd\SwPluginManager\Service\StreamTranslatorInterface;
 
 /**
  * This provider is heavily inspired by https://github.com/shyim/store-plugin-installer

--- a/src/Provider/StoreApiProvider.php
+++ b/src/Provider/StoreApiProvider.php
@@ -10,6 +10,7 @@ namespace sd\SwPluginManager\Provider;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
+use sd\SwPluginManager\Service\StoreApiConnectorInterface;
 use sd\SwPluginManager\Service\StreamTranslatorInterface;
 
 /**
@@ -19,154 +20,21 @@ class StoreApiProvider implements ProviderInterface
 {
     const BASE_URL = 'https://api.shopware.com';
 
-    /** @var Client */
-    private $guzzleClient;
-
-    /** @var StreamTranslatorInterface */
-    private $streamTranslator;
+    /** @var StoreApiConnectorInterface */
+    private $storeApiConnector;
 
     public function __construct(
-        Client $guzzleClient,
-        StreamTranslatorInterface $streamTranslator
+        StoreApiConnectorInterface $storeApiConnector
     ) {
-        $this->guzzleClient = $guzzleClient;
-        $this->streamTranslator = $streamTranslator;
+        $this->storeApiConnector = $storeApiConnector;
     }
 
     public function loadFile($parameters)
     {
-        // TODO: Clean up this messy code (Refactor it to own classes etc.)
-        $user = getenv('SHOPWARE_ACCOUNT_USER');
-        if (false === $user || '' === trim($user)) {
-            throw new \RuntimeException('Environment variable "SHOPWARE_ACCOUNT_USER" should be available');
-        }
-
-        $password = getenv('SHOPWARE_ACCOUNT_PASSWORD');
-        if (false === $password || '' === trim($password)) {
-            throw new \RuntimeException('Environment variable "SHOPWARE_ACCOUNT_PASSWORD" should be available');
-        }
-
-        $shopDomain = getenv('SHOPWARE_SHOP_DOMAIN');
-        if (false === $shopDomain || '' === trim($shopDomain)) {
-            throw new \RuntimeException('Environment variable "SHOPWARE_SHOP_DOMAIN" should be available');
-        }
-
         $name = $parameters['pluginId'];
         $version = $parameters['version'];
 
-        $accessTokenResponse = $this->guzzleClient->post(
-            self::BASE_URL . '/accesstokens',
-            [
-                RequestOptions::JSON => [
-                    'shopwareId'    => $user,
-                    'password'      => $password,
-                ],
-            ]
-        );
-        if (200 === $accessTokenResponse->getStatusCode()) {
-            $accessTokenData = $this->streamTranslator->translateToArray($accessTokenResponse->getBody());
-            $shops = [];
-
-            $partnerResponse = $this->guzzleClient->get(
-                self::BASE_URL . '/partners/' . $accessTokenData['userId'],
-                [
-                    RequestOptions::HEADERS => [
-                        'X-Shopware-Token'  => $accessTokenData['token'],
-                    ],
-                ]
-            );
-
-            if (200 === $partnerResponse->getStatusCode()) {
-                $partnerData = $this->streamTranslator->translateToArray($partnerResponse->getBody());
-                $partnerId = $partnerData['partnerId'];
-                if (false === empty($partnerId)) {
-                    $clientshopsResponse = $this->guzzleClient->get(
-                        self::BASE_URL . '/partners/' . $accessTokenData['userId'] . '/clientshops',
-                        [
-                            RequestOptions::HEADERS => [
-                                'X-Shopware-Token'  => $accessTokenData['token'],
-                            ],
-                        ]
-                    );
-
-                    $shops = array_merge($shops, $this->streamTranslator->translateToArray($clientshopsResponse->getBody()));
-                }
-            }
-
-            $shopsResponse = $this->guzzleClient->get(
-                self::BASE_URL . '/shops?userId=' . $accessTokenData['userId'],
-                [
-                    RequestOptions::HEADERS => [
-                        'X-Shopware-Token'  => $accessTokenData['token'],
-                    ],
-                ]
-            );
-
-            if (200 === $shopsResponse->getStatusCode()) {
-                $shops = array_merge($shops, $this->streamTranslator->translateToArray($shopsResponse->getBody()));
-            }
-
-            $shops = array_filter($shops, function ($shop) use ($shopDomain) {
-                return $shop['domain'] === $shopDomain || ('.' === substr($shop['domain'], 0, 1) && false !== strpos($shop['domain'], $shopDomain));
-            });
-
-            if (0 === count($shops)) {
-                throw new \RuntimeException(sprintf('Shop with given domain "%s" does not exist!', $shopDomain));
-            }
-
-            $shop = array_values($shops)[0];
-
-            $licenseResponse = $this->guzzleClient->get(
-                self::BASE_URL . '/licenses?shopId=' . $shop['id'] . '&partnerId=' . $accessTokenData['userId'],
-                [
-                    RequestOptions::HEADERS => [
-                        'X-Shopware-Token'  => $accessTokenData['token'],
-                    ],
-                ]
-            );
-
-            if (200 === $licenseResponse->getStatusCode()) {
-                $licenses = $this->streamTranslator->translateToArray($licenseResponse->getBody());
-
-                $plugin = array_filter($licenses, function ($license) use ($name) {
-                    // Basic Plugins like SwagCore
-                    if (!isset($license['plugin'])) {
-                        return false;
-                    }
-
-                    return $license['plugin']['name'] === $name || $license['plugin']['code'] === $name;
-                });
-
-                if (empty($plugin)) {
-                    throw new \RuntimeException(sprintf('Plugin with name "%s" is not available in your Account. Please buy the plugin first', $name));
-                }
-
-                $plugin = array_values($plugin)[0];
-                // Fix plugin name
-                $name = $plugin['plugin']['name'];
-                $versions = array_column($plugin['plugin']['binaries'], 'version');
-                if (!in_array($version, $versions)) {
-                    throw new \RuntimeException(sprintf('Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $name, $version, implode(', ', array_reverse($versions))));
-                }
-
-                $binaryVersion = array_values(array_filter($plugin['plugin']['binaries'], function ($binary) use ($version) {
-                    return $binary['version'] === $version;
-                }))[0];
-
-                $tmpName = '/tmp/sw-plugin-' . $name . $version;
-                $this->guzzleClient->get(
-                    self::BASE_URL . $binaryVersion['filePath'] . '?shopId=' . $shop['id'],
-                    [
-                        RequestOptions::HEADERS => [
-                            'X-Shopware-Token'  => $accessTokenData['token'],
-                        ],
-                        RequestOptions::SINK => $tmpName,
-                    ]
-                );
-
-                return $tmpName;
-            }
-        }
+        return $this->storeApiConnector->loadPlugin($name, $version);
     }
 
     public function supports($providerName)

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -72,6 +72,11 @@ services:
     class: sd\SwPluginManager\Provider\StoreApiProvider
     tags: ['sd.plugin.provider']
     arguments:
+      - '@sd.service.store_api_connector'
+
+  sd.service.store_api_connector:
+    class: sd\SwPluginManager\Service\StoreApiConnector
+    arguments:
       - '@sd.external.guzzle'
       - '@sd.service.stream_translator'
 

--- a/src/Service/StoreApiConnector.php
+++ b/src/Service/StoreApiConnector.php
@@ -9,6 +9,7 @@
 namespace sd\SwPluginManager\Service;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
 
 class StoreApiConnector implements StoreApiConnectorInterface
 {
@@ -26,5 +27,138 @@ class StoreApiConnector implements StoreApiConnectorInterface
     ) {
         $this->guzzleClient = $guzzleClient;
         $this->streamTranslator = $streamTranslator;
+    }
+
+    public function loadPlugin($pluginId, $version)
+    {
+        // TODO: Clean up this messy code (Refactor it to own classes etc.)
+        $user = getenv('SHOPWARE_ACCOUNT_USER');
+        if (false === $user || '' === trim($user)) {
+            throw new \RuntimeException('Environment variable "SHOPWARE_ACCOUNT_USER" should be available');
+        }
+
+        $password = getenv('SHOPWARE_ACCOUNT_PASSWORD');
+        if (false === $password || '' === trim($password)) {
+            throw new \RuntimeException('Environment variable "SHOPWARE_ACCOUNT_PASSWORD" should be available');
+        }
+
+        $shopDomain = getenv('SHOPWARE_SHOP_DOMAIN');
+        if (false === $shopDomain || '' === trim($shopDomain)) {
+            throw new \RuntimeException('Environment variable "SHOPWARE_SHOP_DOMAIN" should be available');
+        }
+
+        $accessTokenResponse = $this->guzzleClient->post(
+            self::BASE_URL . '/accesstokens',
+            [
+                RequestOptions::JSON => [
+                    'shopwareId'    => $user,
+                    'password'      => $password,
+                ],
+            ]
+        );
+        if (200 === $accessTokenResponse->getStatusCode()) {
+            $accessTokenData = $this->streamTranslator->translateToArray($accessTokenResponse->getBody());
+            $shops = [];
+
+            $partnerResponse = $this->guzzleClient->get(
+                self::BASE_URL . '/partners/' . $accessTokenData['userId'],
+                [
+                    RequestOptions::HEADERS => [
+                        'X-Shopware-Token'  => $accessTokenData['token'],
+                    ],
+                ]
+            );
+
+            if (200 === $partnerResponse->getStatusCode()) {
+                $partnerData = $this->streamTranslator->translateToArray($partnerResponse->getBody());
+                $partnerId = $partnerData['partnerId'];
+                if (false === empty($partnerId)) {
+                    $clientshopsResponse = $this->guzzleClient->get(
+                        self::BASE_URL . '/partners/' . $accessTokenData['userId'] . '/clientshops',
+                        [
+                            RequestOptions::HEADERS => [
+                                'X-Shopware-Token'  => $accessTokenData['token'],
+                            ],
+                        ]
+                    );
+
+                    $shops = array_merge($shops, $this->streamTranslator->translateToArray($clientshopsResponse->getBody()));
+                }
+            }
+
+            $shopsResponse = $this->guzzleClient->get(
+                self::BASE_URL . '/shops?userId=' . $accessTokenData['userId'],
+                [
+                    RequestOptions::HEADERS => [
+                        'X-Shopware-Token'  => $accessTokenData['token'],
+                    ],
+                ]
+            );
+
+            if (200 === $shopsResponse->getStatusCode()) {
+                $shops = array_merge($shops, $this->streamTranslator->translateToArray($shopsResponse->getBody()));
+            }
+
+            $shops = array_filter($shops, function ($shop) use ($shopDomain) {
+                return $shop['domain'] === $shopDomain || ('.' === substr($shop['domain'], 0, 1) && false !== strpos($shop['domain'], $shopDomain));
+            });
+
+            if (0 === count($shops)) {
+                throw new \RuntimeException(sprintf('Shop with given domain "%s" does not exist!', $shopDomain));
+            }
+
+            $shop = array_values($shops)[0];
+
+            $licenseResponse = $this->guzzleClient->get(
+                self::BASE_URL . '/licenses?shopId=' . $shop['id'] . '&partnerId=' . $accessTokenData['userId'],
+                [
+                    RequestOptions::HEADERS => [
+                        'X-Shopware-Token'  => $accessTokenData['token'],
+                    ],
+                ]
+            );
+
+            if (200 === $licenseResponse->getStatusCode()) {
+                $licenses = $this->streamTranslator->translateToArray($licenseResponse->getBody());
+
+                $plugin = array_filter($licenses, function ($license) use ($pluginId) {
+                    // Basic Plugins like SwagCore
+                    if (!isset($license['plugin'])) {
+                        return false;
+                    }
+
+                    return $license['plugin']['name'] === $pluginId || $license['plugin']['code'] === $pluginId;
+                });
+
+                if (empty($plugin)) {
+                    throw new \RuntimeException(sprintf('Plugin with name "%s" is not available in your Account. Please buy the plugin first', $pluginId));
+                }
+
+                $plugin = array_values($plugin)[0];
+                // Fix plugin name
+                $pluginId = $plugin['plugin']['name'];
+                $versions = array_column($plugin['plugin']['binaries'], 'version');
+                if (!in_array($version, $versions)) {
+                    throw new \RuntimeException(sprintf('Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $pluginId, $version, implode(', ', array_reverse($versions))));
+                }
+
+                $binaryVersion = array_values(array_filter($plugin['plugin']['binaries'], function ($binary) use ($version) {
+                    return $binary['version'] === $version;
+                }))[0];
+
+                $tmpName = '/tmp/sw-plugin-' . $pluginId . $version;
+                $this->guzzleClient->get(
+                    self::BASE_URL . $binaryVersion['filePath'] . '?shopId=' . $shop['id'],
+                    [
+                        RequestOptions::HEADERS => [
+                            'X-Shopware-Token'  => $accessTokenData['token'],
+                        ],
+                        RequestOptions::SINK => $tmpName,
+                    ]
+                );
+
+                return $tmpName;
+            }
+        }
     }
 }

--- a/src/Service/StoreApiConnector.php
+++ b/src/Service/StoreApiConnector.php
@@ -8,7 +8,23 @@
 
 namespace sd\SwPluginManager\Service;
 
+use GuzzleHttp\Client;
+
 class StoreApiConnector implements StoreApiConnectorInterface
 {
+    const BASE_URL = 'https://api.shopware.com';
 
+    /** @var Client */
+    private $guzzleClient;
+
+    /** @var StreamTranslatorInterface */
+    private $streamTranslator;
+
+    public function __construct(
+        Client $guzzleClient,
+        StreamTranslatorInterface $streamTranslator
+    ) {
+        $this->guzzleClient = $guzzleClient;
+        $this->streamTranslator = $streamTranslator;
+    }
 }

--- a/src/Service/StoreApiConnector.php
+++ b/src/Service/StoreApiConnector.php
@@ -23,7 +23,7 @@ class StoreApiConnector implements StoreApiConnectorInterface
 
     /** @var string|null */
     private $accessToken;
-    
+
     /** @var string|null */
     private $userId;
 
@@ -101,7 +101,7 @@ class StoreApiConnector implements StoreApiConnectorInterface
 
         return $this->accessToken;
     }
-    
+
     private function getUserId()
     {
         if (null !== $this->userId) {
@@ -180,6 +180,7 @@ class StoreApiConnector implements StoreApiConnectorInterface
                 $shops = array_merge($shops, $this->streamTranslator->translateToArray($clientshopsResponse->getBody()));
             }
         }
+
         return $shops;
     }
 
@@ -204,6 +205,7 @@ class StoreApiConnector implements StoreApiConnectorInterface
         if (200 === $shopsResponse->getStatusCode()) {
             $shops = array_merge($shops, $this->streamTranslator->translateToArray($shopsResponse->getBody()));
         }
+
         return $shops;
     }
 
@@ -238,7 +240,7 @@ class StoreApiConnector implements StoreApiConnectorInterface
     /**
      * Filters out plugin from licenses and throws an exception if no plugin was found
      *
-     * @param string $pluginId
+     * @param string     $pluginId
      * @param string[][] $licenses
      *
      * @return string[]

--- a/src/Service/StoreApiConnector.php
+++ b/src/Service/StoreApiConnector.php
@@ -40,8 +40,6 @@ class StoreApiConnector implements StoreApiConnectorInterface
 
     public function loadPlugin($pluginId, $version)
     {
-        // TODO: Clean up this messy code (Refactor it to own classes etc.)
-
         $shopDomain = getenv('SHOPWARE_SHOP_DOMAIN');
         if (false === $shopDomain || '' === trim($shopDomain)) {
             throw new \RuntimeException('Environment variable "SHOPWARE_SHOP_DOMAIN" should be available');

--- a/src/Service/StoreApiConnector.php
+++ b/src/Service/StoreApiConnector.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Created by solutionDrive GmbH
+ *
+ * @copyright 2018 solutionDrive GmbH
+ */
+
+namespace sd\SwPluginManager\Service;
+
+class StoreApiConnector implements StoreApiConnectorInterface
+{
+
+}

--- a/src/Service/StoreApiConnector.php
+++ b/src/Service/StoreApiConnector.php
@@ -154,6 +154,8 @@ class StoreApiConnector implements StoreApiConnectorInterface
 
             return $tmpName;
         }
+
+        return '';
     }
 
     private function getAccessToken()

--- a/src/Service/StoreApiConnector.php
+++ b/src/Service/StoreApiConnector.php
@@ -21,6 +21,12 @@ class StoreApiConnector implements StoreApiConnectorInterface
     /** @var StreamTranslatorInterface */
     private $streamTranslator;
 
+    /** @var string|null */
+    private $accessToken;
+    
+    /** @var string|null */
+    private $userId;
+
     /** @var bool */
     private $isPartnerAccount = false;
 
@@ -35,6 +41,147 @@ class StoreApiConnector implements StoreApiConnectorInterface
     public function loadPlugin($pluginId, $version)
     {
         // TODO: Clean up this messy code (Refactor it to own classes etc.)
+
+        $shopDomain = getenv('SHOPWARE_SHOP_DOMAIN');
+        if (false === $shopDomain || '' === trim($shopDomain)) {
+            throw new \RuntimeException('Environment variable "SHOPWARE_SHOP_DOMAIN" should be available');
+        }
+
+        $shops = [];
+
+        $partnerResponse = $this->guzzleClient->get(
+            self::BASE_URL . '/partners/' . $this->getUserId(),
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => $this->getAccessToken(),
+                ],
+            ]
+        );
+
+        if (200 === $partnerResponse->getStatusCode()) {
+            $partnerData = $this->streamTranslator->translateToArray($partnerResponse->getBody());
+            if (false === empty($partnerData['partnerId'])) {
+                $this->isPartnerAccount = true;
+            }
+
+            if (true === $this->isPartnerAccount) {
+                $clientshopsResponse = $this->guzzleClient->get(
+                    self::BASE_URL . '/partners/' . $this->getUserId() . '/clientshops',
+                    [
+                        RequestOptions::HEADERS => [
+                            'X-Shopware-Token'  => $this->getAccessToken(),
+                        ],
+                    ]
+                );
+
+                $shops = array_merge($shops, $this->streamTranslator->translateToArray($clientshopsResponse->getBody()));
+            }
+        }
+
+        $shopsResponse = $this->guzzleClient->get(
+            self::BASE_URL . '/shops?userId=' . $this->getUserId(),
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => $this->getAccessToken(),
+                ],
+            ]
+        );
+
+        if (200 === $shopsResponse->getStatusCode()) {
+            $shops = array_merge($shops, $this->streamTranslator->translateToArray($shopsResponse->getBody()));
+        }
+
+        $shops = array_filter($shops, function ($shop) use ($shopDomain) {
+            return $shop['domain'] === $shopDomain || ('.' === substr($shop['domain'], 0, 1) && false !== strpos($shop['domain'], $shopDomain));
+        });
+
+        if (0 === count($shops)) {
+            throw new \RuntimeException(sprintf('Shop with given domain "%s" does not exist!', $shopDomain));
+        }
+
+        $shop = array_values($shops)[0];
+
+        $licenseUrl = self::BASE_URL . '/licenses?shopId=' . $shop['id'];
+        if (true === $this->isPartnerAccount) {
+            $licenseUrl .= '&partnerId=' . $this->getUserId();
+        }
+
+        $licenseResponse = $this->guzzleClient->get(
+            $licenseUrl,
+            [
+                RequestOptions::HEADERS => [
+                    'X-Shopware-Token'  => $this->getAccessToken(),
+                ],
+            ]
+        );
+
+        if (200 === $licenseResponse->getStatusCode()) {
+            $licenses = $this->streamTranslator->translateToArray($licenseResponse->getBody());
+
+            $plugin = array_filter($licenses, function ($license) use ($pluginId) {
+                // Basic Plugins like SwagCore
+                if (!isset($license['plugin'])) {
+                    return false;
+                }
+
+                return $license['plugin']['name'] === $pluginId || $license['plugin']['code'] === $pluginId;
+            });
+
+            if (empty($plugin)) {
+                throw new \RuntimeException(sprintf('Plugin with name "%s" is not available in your Account. Please buy the plugin first', $pluginId));
+            }
+
+            $plugin = array_values($plugin)[0];
+            // Fix plugin name
+            $pluginId = $plugin['plugin']['name'];
+            $versions = array_column($plugin['plugin']['binaries'], 'version');
+            if (!in_array($version, $versions)) {
+                throw new \RuntimeException(sprintf('Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $pluginId, $version, implode(', ', array_reverse($versions))));
+            }
+
+            $binaryVersion = array_values(array_filter($plugin['plugin']['binaries'], function ($binary) use ($version) {
+                return $binary['version'] === $version;
+            }))[0];
+
+            $tmpName = '/tmp/sw-plugin-' . $pluginId . $version;
+            $this->guzzleClient->get(
+                self::BASE_URL . $binaryVersion['filePath'] . '?shopId=' . $shop['id'],
+                [
+                    RequestOptions::HEADERS => [
+                        'X-Shopware-Token'  => $this->getAccessToken(),
+                    ],
+                    RequestOptions::SINK => $tmpName,
+                ]
+            );
+
+            return $tmpName;
+        }
+    }
+
+    private function getAccessToken()
+    {
+        if (null !== $this->accessToken) {
+            return $this->accessToken;
+        }
+
+        $this->loadAccessTokens();
+
+        return $this->accessToken;
+    }
+    
+    private function getUserId()
+    {
+        if (null !== $this->userId) {
+            return $this->userId;
+        }
+
+        $this->loadAccessTokens();
+
+        return $this->userId;
+    }
+
+    private function loadAccessTokens()
+    {
         $user = getenv('SHOPWARE_ACCOUNT_USER');
         if (false === $user || '' === trim($user)) {
             throw new \RuntimeException('Environment variable "SHOPWARE_ACCOUNT_USER" should be available');
@@ -45,131 +192,19 @@ class StoreApiConnector implements StoreApiConnectorInterface
             throw new \RuntimeException('Environment variable "SHOPWARE_ACCOUNT_PASSWORD" should be available');
         }
 
-        $shopDomain = getenv('SHOPWARE_SHOP_DOMAIN');
-        if (false === $shopDomain || '' === trim($shopDomain)) {
-            throw new \RuntimeException('Environment variable "SHOPWARE_SHOP_DOMAIN" should be available');
-        }
-
         $accessTokenResponse = $this->guzzleClient->post(
             self::BASE_URL . '/accesstokens',
             [
                 RequestOptions::JSON => [
-                    'shopwareId'    => $user,
-                    'password'      => $password,
+                    'shopwareId' => $user,
+                    'password' => $password,
                 ],
             ]
         );
         if (200 === $accessTokenResponse->getStatusCode()) {
             $accessTokenData = $this->streamTranslator->translateToArray($accessTokenResponse->getBody());
-            $shops = [];
-
-            $partnerResponse = $this->guzzleClient->get(
-                self::BASE_URL . '/partners/' . $accessTokenData['userId'],
-                [
-                    RequestOptions::HEADERS => [
-                        'X-Shopware-Token'  => $accessTokenData['token'],
-                    ],
-                ]
-            );
-
-            if (200 === $partnerResponse->getStatusCode()) {
-                $partnerData = $this->streamTranslator->translateToArray($partnerResponse->getBody());
-                if (false === empty($partnerData['partnerId'])) {
-                    $this->isPartnerAccount = true;
-                }
-
-                if (true === $this->isPartnerAccount) {
-                    $clientshopsResponse = $this->guzzleClient->get(
-                        self::BASE_URL . '/partners/' . $accessTokenData['userId'] . '/clientshops',
-                        [
-                            RequestOptions::HEADERS => [
-                                'X-Shopware-Token'  => $accessTokenData['token'],
-                            ],
-                        ]
-                    );
-
-                    $shops = array_merge($shops, $this->streamTranslator->translateToArray($clientshopsResponse->getBody()));
-                }
-            }
-
-            $shopsResponse = $this->guzzleClient->get(
-                self::BASE_URL . '/shops?userId=' . $accessTokenData['userId'],
-                [
-                    RequestOptions::HEADERS => [
-                        'X-Shopware-Token'  => $accessTokenData['token'],
-                    ],
-                ]
-            );
-
-            if (200 === $shopsResponse->getStatusCode()) {
-                $shops = array_merge($shops, $this->streamTranslator->translateToArray($shopsResponse->getBody()));
-            }
-
-            $shops = array_filter($shops, function ($shop) use ($shopDomain) {
-                return $shop['domain'] === $shopDomain || ('.' === substr($shop['domain'], 0, 1) && false !== strpos($shop['domain'], $shopDomain));
-            });
-
-            if (0 === count($shops)) {
-                throw new \RuntimeException(sprintf('Shop with given domain "%s" does not exist!', $shopDomain));
-            }
-
-            $shop = array_values($shops)[0];
-
-            $licenseUrl = self::BASE_URL . '/licenses?shopId=' . $shop['id'];
-            if (true === $this->isPartnerAccount) {
-                $licenseUrl .= '&partnerId=' . $accessTokenData['userId'];
-            }
-
-            $licenseResponse = $this->guzzleClient->get(
-                $licenseUrl,
-                [
-                    RequestOptions::HEADERS => [
-                        'X-Shopware-Token'  => $accessTokenData['token'],
-                    ],
-                ]
-            );
-
-            if (200 === $licenseResponse->getStatusCode()) {
-                $licenses = $this->streamTranslator->translateToArray($licenseResponse->getBody());
-
-                $plugin = array_filter($licenses, function ($license) use ($pluginId) {
-                    // Basic Plugins like SwagCore
-                    if (!isset($license['plugin'])) {
-                        return false;
-                    }
-
-                    return $license['plugin']['name'] === $pluginId || $license['plugin']['code'] === $pluginId;
-                });
-
-                if (empty($plugin)) {
-                    throw new \RuntimeException(sprintf('Plugin with name "%s" is not available in your Account. Please buy the plugin first', $pluginId));
-                }
-
-                $plugin = array_values($plugin)[0];
-                // Fix plugin name
-                $pluginId = $plugin['plugin']['name'];
-                $versions = array_column($plugin['plugin']['binaries'], 'version');
-                if (!in_array($version, $versions)) {
-                    throw new \RuntimeException(sprintf('Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $pluginId, $version, implode(', ', array_reverse($versions))));
-                }
-
-                $binaryVersion = array_values(array_filter($plugin['plugin']['binaries'], function ($binary) use ($version) {
-                    return $binary['version'] === $version;
-                }))[0];
-
-                $tmpName = '/tmp/sw-plugin-' . $pluginId . $version;
-                $this->guzzleClient->get(
-                    self::BASE_URL . $binaryVersion['filePath'] . '?shopId=' . $shop['id'],
-                    [
-                        RequestOptions::HEADERS => [
-                            'X-Shopware-Token'  => $accessTokenData['token'],
-                        ],
-                        RequestOptions::SINK => $tmpName,
-                    ]
-                );
-
-                return $tmpName;
-            }
+            $this->accessToken = $accessTokenData['token'];
+            $this->userId = $accessTokenData['userId'];
         }
     }
 }

--- a/src/Service/StoreApiConnectorInterface.php
+++ b/src/Service/StoreApiConnectorInterface.php
@@ -10,5 +10,5 @@ namespace sd\SwPluginManager\Service;
 
 interface StoreApiConnectorInterface
 {
-
+    public function loadPlugin($pluginId, $version);
 }

--- a/src/Service/StoreApiConnectorInterface.php
+++ b/src/Service/StoreApiConnectorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Created by solutionDrive GmbH
+ *
+ * @copyright 2018 solutionDrive GmbH
+ */
+
+namespace sd\SwPluginManager\Service;
+
+interface StoreApiConnectorInterface
+{
+
+}


### PR DESCRIPTION
Moves the store api communication to an own service for a better overview

Also adds support for loading plugins without having a partner account