### PR TITLE
Changes behaviour of extracting folderName

### DIFF
--- a/src/Worker/PluginExtractor.php
+++ b/src/Worker/PluginExtractor.php
@@ -66,7 +66,7 @@ class PluginExtractor implements PluginExtractorInterface
         // Get plugins key to return
         // @TODO Verify that this works with lots of plugins (but it should...)
         $stat = $zipArchive->statIndex(0);
-        $folderName = trim($stat['name'], '/');
+        $folderName = explode('/', $stat['name'])[0];
         $extractToPath = $this->getExtractToPath($folderName);
 
         $extractResult = $zipArchive->extractTo($extractToPath);


### PR DESCRIPTION
because by some plugins stat['name'] has returned 'Frontend/PluginName' instead of 'Frontend/' alone